### PR TITLE
Sort array returned by getGroupedTerms()

### DIFF
--- a/core/components/glossary/model/glossary/glossarybase.class.php
+++ b/core/components/glossary/model/glossary/glossarybase.class.php
@@ -131,6 +131,7 @@ class GlossaryBase
             }
             $letters[$firstLetter][] = $term;
         };
+        ksort($letters, SORT_NATURAL);
         return $letters;
     }
 


### PR DESCRIPTION
## What does it do?

Modified glossary base class member function getGroupedTerms() to sort the returned `$letters` array by array key.
## Why is it needed?

I couldn't find another way to sort the list of grouped terms (and the navigation) alphabetically without this patch...? Maybe I misunderstand how to use the Snippet.
