### PR TITLE
Remove "#" from name attribute

### DIFF
--- a/core/components/glossary/elements/chunks/listGroupTpl.chunk.html
+++ b/core/components/glossary/elements/chunks/listGroupTpl.chunk.html
@@ -1,3 +1,3 @@
-<a name="#[[+letter]]"></a>
+<a name="[[+letter]]"></a>
 <h4>[[+letter]]</h4>
 [[+items]]


### PR DESCRIPTION
I think it was an error that the `name` attribute had a `#` in it?
